### PR TITLE
A few updates

### DIFF
--- a/.cherry-pick
+++ b/.cherry-pick
@@ -3,3 +3,7 @@ git cherry-pick bbd205543b09139f2f57f21099eb366c9f183d76 -X theirs --no-commit
 
 # add gaudi 39
 git cherry-pick 5ebf45861f688337dddcdee2242d4f479a832d06 -X theirs --no-commit
+
+# openloops: Fix application of cmodel to compilation for aarch64.
+git cherry-pick a14f10e8825fd25e0615095feaa548b1938fffac -X theirs --no-commit
+git cherry-pick e76f8fda2d959fdf7a262eb539a4002a6a0c900f -X theirs --no-commit

--- a/.github/workflows/full-rebuild.yml
+++ b/.github/workflows/full-rebuild.yml
@@ -163,7 +163,7 @@ jobs:
           file: ./${{matrix.os.dir}}/Dockerfile-sim
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-            IMAGE=${{ env.REGISTRY }}/${{env.OWNER_LC}}
-            REPOSITORY=${{ github.repository }}
+            REPOSITORY=${{ env.REGISTRY }}/${{env.OWNER_LC}}
+            GITHUB_REPOSITORY=${{ github.repository }}
             MUCOLL_SHA=${{ github.sha }}
           tags: ${{ env.REGISTRY }}/${{env.OWNER_LC}}/mucoll-sim:${{steps.meta.outputs.version}}-${{matrix.os.suffix}}

--- a/.github/workflows/minimal-rebuild.yml
+++ b/.github/workflows/minimal-rebuild.yml
@@ -121,7 +121,7 @@ jobs:
           file: ./${{matrix.os.dir}}/Dockerfile-sim
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-            IMAGE=${{ env.REGISTRY }}/${{env.OWNER_LC}}
-            REPOSITORY=${{ github.repository }}
+            REPOSITORY=${{ env.REGISTRY }}/${{env.OWNER_LC}}
+            GITHUB_REPOSITORY=${{ github.repository }}
             MUCOLL_SHA=${{ github.sha }}
           tags: ${{ env.REGISTRY }}/${{env.OWNER_LC}}/mucoll-sim:${{steps.meta.outputs.version}}-${{matrix.os.suffix}}

--- a/.github/workflows/mucoll-rebuild.yml
+++ b/.github/workflows/mucoll-rebuild.yml
@@ -71,7 +71,7 @@ jobs:
           file: ./${{matrix.os.dir}}/Dockerfile-sim
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-            IMAGE=${{ env.REGISTRY }}/${{env.OWNER_LC}}
-            REPOSITORY=${{ github.repository }}
+            REPOSITORY=${{ env.REGISTRY }}/${{env.OWNER_LC}}
+            GITHUB_REPOSITORY=${{ github.repository }}
             MUCOLL_SHA=${{ github.sha }}
           tags: ${{ env.REGISTRY }}/${{env.OWNER_LC}}/${{ env.IMAGE_NAME}}:${{steps.meta.outputs.version}}-${{matrix.os.suffix}}

--- a/.key4hep-commit
+++ b/.key4hep-commit
@@ -1,1 +1,1 @@
-dc0b2bc4aaad8f3ef5f3c7f62ff5b0277a554eee
+334aa25cf90cbbaf693ac29509d4d7b790effecb

--- a/AlmaLinux9/Dockerfile-minimal
+++ b/AlmaLinux9/Dockerfile-minimal
@@ -8,7 +8,7 @@ ARG REPOSITORY=madbaron
 FROM ${REPOSITORY}/mucoll-spack:${VERSION}-alma9
 
 # Picking specific key4hep commit
-ARG KEY4HEP_COMMIT=475d26f0a62283a29e87b38399b128798d2b81a8
+ARG KEY4HEP_COMMIT=334aa25cf90cbbaf693ac29509d4d7b790effecb
 
 RUN source /opt/setup_spack.sh && \
     REPOPATH=${SPACK_ROOT}/var/key4hep-spack && \
@@ -30,18 +30,18 @@ RUN source /opt/setup_spack.sh && \
 
 # Create the release environment
 RUN source /opt/setup_spack.sh && \
-    cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-dev-base && \
+    cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-dev-external && \
     spack env activate . && \
     cd - && \
     echo "source /opt/setup_spack.sh" > ${HOME}/setup_env.sh && \
-    echo "cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-dev-base" >> ${HOME}/setup_env.sh && \
+    echo "cd ${SPACK_ROOT}/var/key4hep-spack/environments/key4hep-dev-external" >> ${HOME}/setup_env.sh && \
     echo "spack env activate ." >> ${HOME}/setup_env.sh && \
     echo "cd -" >> ${HOME}/setup_env.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the stack reusing system packages as external
 RUN source ${HOME}/setup_env.sh && \
-    spack add key4hep-base-stack && \
+    spack add key4hep-external-stack && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
@@ -55,5 +55,3 @@ RUN source ${HOME}/setup_env.sh && \
 RUN source ${HOME}/setup_env.sh && \
     echo "source ${SPACK_ENV}/.spack-env/view/setup.sh" > /opt/setup_k4base.sh && \
     echo "alias setup_k4base=\"source /opt/setup_k4base.sh\"" >> /etc/profile.d/aliases.sh
-
-

--- a/AlmaLinux9/Dockerfile-minimal
+++ b/AlmaLinux9/Dockerfile-minimal
@@ -41,7 +41,6 @@ RUN source /opt/setup_spack.sh && \
 
 # Concretizing the stack reusing system packages as external
 RUN source ${HOME}/setup_env.sh && \
-    spack add key4hep-external-stack && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging

--- a/AlmaLinux9/Dockerfile-sim
+++ b/AlmaLinux9/Dockerfile-sim
@@ -7,8 +7,8 @@ ARG VERSION=master
 ARG REPOSITORY=madbaron
 FROM ${REPOSITORY}/mucoll-minimal:${VERSION}-alma9
 
-ARG MUCOLL_SHA=1c4ba29cebeb3e9744626ffc0d04e6ac3f22265e
-ARG GITHUB_REPOSITORY=madbaron/mucoll-spack
+ARG MUCOLL_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
+ARG GITHUB_REPOSITORY=kkrizka/mucoll-spack
 
 # Adding repository: MuColl
 RUN source /opt/setup_spack.sh && \

--- a/AlmaLinux9/Dockerfile-sim
+++ b/AlmaLinux9/Dockerfile-sim
@@ -4,16 +4,16 @@
 ###############################################################################
 
 ARG VERSION=master
-ARG IMAGE=madbaron
-FROM ${IMAGE}/mucoll-minimal:${VERSION}-alma9
+ARG REPOSITORY=madbaron
+FROM ${REPOSITORY}/mucoll-minimal:${VERSION}-alma9
 
 ARG MUCOLL_SHA=1c4ba29cebeb3e9744626ffc0d04e6ac3f22265e
-ARG REPOSITORY=madbaron/mucoll-spack
+ARG GITHUB_REPOSITORY=madbaron/mucoll-spack
 
 # Adding repository: MuColl
 RUN source /opt/setup_spack.sh && \
     REPOPATH=${SPACK_ROOT}/var/mucoll-spack && \
-    git clone https://github.com/${REPOSITORY} ${REPOPATH} && \
+    git clone https://github.com/${GITHUB_REPOSITORY} ${REPOPATH} && \
     cd ${REPOPATH} && \
     git checkout ${MUCOLL_SHA} && \
     cd -
@@ -41,7 +41,6 @@ RUN source /opt/setup_spack.sh && \
 
 # Concretizing the MuColl stack reusing system packages as external
 RUN source ${HOME}/setup_env.sh && \
-    #    spack add mucoll-stack && \
     spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging

--- a/AlmaLinux9/Dockerfile-spack
+++ b/AlmaLinux9/Dockerfile-spack
@@ -34,10 +34,6 @@ RUN if [ -n "${SPACK_COMMIT}" ]; then \
       git checkout ${SPACK_COMMIT}; \
     fi
 
-#RUN source /opt/setup_spack.sh && \
-#    spack install gcc@14.2.0 && \
-#    spack clean -a
-
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
 RUN source /opt/setup_spack.sh && \

--- a/AlmaLinux9/build.sh
+++ b/AlmaLinux9/build.sh
@@ -23,10 +23,10 @@ echo "### Building Docker images: ${REPOSITORY}/<IMAGE>:${VERSION}-${SUFFIX}"
 echo
 #
 echo "### Building the Spack image" && \
-${DOCKER} build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-spack .
+${DOCKER} build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY=${REPOSITORY} --build-arg VERSION=${VERSION} -f Dockerfile-spack .
 #
 echo "### Building the minimal Spack image" && \
-${DOCKER} build -t ${REPOSITORY}/mucoll-minimal:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-minimal .
+${DOCKER} build -t ${REPOSITORY}/mucoll-minimal:${VERSION}-${SUFFIX} --build-arg REPOSITORY=${REPOSITORY} --build-arg VERSION=${VERSION} -f Dockerfile-minimal .
 #
 echo "### Building the MuColl simulation image"
-${DOCKER} build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-sim .
+${DOCKER} build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY=${REPOSITORY} --build-arg VERSION=${VERSION} -f Dockerfile-sim .

--- a/AlmaLinux9/build.sh
+++ b/AlmaLinux9/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# USAGE: ./build.sh [<version>] [<repository>]
+
+VERSION="release"
+REPOSITORY="infnpd"
+SUFFIX="alma9"
+
+if [ "$#" -gt 0 ]; then
+	VERSION=$1
+fi
+if [ "$#" -gt 1 ]; then
+	REPOSITORY=$2
+fi
+if [[ -z "${DOCKER}" ]]; then
+    DOCKER="docker"
+fi
+
+# exit when any command fails
+set -e
+
+# The actual building
+echo "### Building Docker images: ${REPOSITORY}/<IMAGE>:${VERSION}-${SUFFIX}"
+echo
+#
+echo "### Building the Spack image" && \
+${DOCKER} build -t ${REPOSITORY}/mucoll-spack:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-spack .
+#
+echo "### Building the minimal Spack image" && \
+${DOCKER} build -t ${REPOSITORY}/mucoll-minimal:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-minimal .
+#
+echo "### Building the MuColl simulation image"
+${DOCKER} build -t ${REPOSITORY}/mucoll-sim:${VERSION}-${SUFFIX} --build-arg REPOSITORY --build-arg VERSION -f Dockerfile-sim .

--- a/README.md
+++ b/README.md
@@ -131,3 +131,18 @@ spack env deactivate
 # Activate the default environment (if in a Docker container)
 spack env activate sim
 ```
+
+## Build Docker Images
+
+The `Dockerfile`s used to build the official releases are provided in this repository. To build a local release, run the following script. The arguments are used to create the image tags.
+
+```shell
+cd AlmaLinux9
+./build.sh REPOSITORY VERSION
+```
+
+Three images are created in sucession:
+
+- `${REPOSITORY}/mucoll-spack:${VERSION}-alma9`: Base OS with developement tools and any Spack installed under `/opt/spack`.
+- `${REPOSITORY}/mucoll-minimal:${VERSION}-alma9`: Contains an minimal Spack environment.
+- `${REPOSITORY}/mucoll-sim:${VERSION}-alma9`: Contains the full Muon Collider Spack environment.

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -34,7 +34,7 @@ spack:
     marlintrkprocessors:
       require: '@master'
     actstracking:
-      require: '@1.3.0'
+      require: '@1.3.1'
     muoncvxddigitiser:
       require: '@master'
 

--- a/packages/actstracking/package.py
+++ b/packages/actstracking/package.py
@@ -16,7 +16,8 @@ class Actstracking(CMakePackage, MCIlcsoftpackage):
     maintainers = ['gianelle', 'kkrizka']
 
     version('main', branch='main')
-    version('1.3.0', sha256='d013a7700ce453054848572603bcfc6fdf4f5a4d', preferred=True)
+    version('1.3.1', sha256='ff9014f17931fa8d883e4d944a5d745a91d03afae7c4fb8d05a95fd7cb54c917', preferred=True)
+    version('1.3.0', sha256='d013a7700ce453054848572603bcfc6fdf4f5a4d')
     version('1.2.2', sha256='be08b87037167892a9b1a7ad601511beaf99423e836841436c6318fef5fa93de')
     version('1.2.1', sha256='747c15a4c937ab09d79afcc956bb1f1f82ce345febfb4bd18462b71e70ae0b29')
     version('1.2', sha256='7390d03ab848f7ad9e67c5aabda8122942a885256775174db30964fb9fe028e1')


### PR DESCRIPTION
- Add a `build.sh` script to build the Docker image locally.
- Add documentation on the Docker images to README.
- Update the `Dockerfile-minimal` to latest version of the `key4hep-dev-external` branch.
- Revert the `Dockerfile-sim` to use a consistent naming with the others. This means using `GITHUB_REPOSITORY` for where to clone `mucoll-spack` from.
- Backport https://github.com/spack/spack/pull/48288 (e.g. build image on MacOS).
- Update ACTSTracking to version v1.3.1. 